### PR TITLE
Benchmarks fix

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -85,30 +85,8 @@ namespace BenchmarkSqlWrite
 
 	[MemoryDiagnoser]
 	[MarkdownExporter]
-	//[Config(typeof(Config))]
-	[InProcess]
 	public class WriteBenchmarks
 	{
-		public class Config : ManualConfig
-		{
-			public Config()
-			{
-				//Add(
-				//	Job.Default.With(
-				//		CsProjCoreToolchain.From(
-				//			new BenchmarkDotNet.Toolchains.DotNetCli.NetCoreAppSettings(
-				//				"netcoreapp3.0",
-				//				"3.0.100-preview-009738",
-				//				"CoreCLR3.0",
-				//				customDotNetCliPath: @"E:\Programming\csharp7\sdk\dotnet.exe"
-				//			)
-				//		)
-				//	)
-				//);
-				Add(Job.Default.With(CsProjCoreToolchain.NetCoreApp30));
-			}
-		}
-
 		private string connectionString;
 
 		private SqlConnection syncConnection;

--- a/SqlBench.csproj
+++ b/SqlBench.csproj
@@ -4,13 +4,10 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <LangVersion>7.3</LangVersion>
-    <!-- <RuntimeFrameworkVersion>3.0.100-alpha1-009638</RuntimeFrameworkVersion> modify build in this line -->
-    <!--<RuntimeIdentifier>win-x64</RuntimeIdentifier>  make self-contained -->
   </PropertyGroup>
 
   <ItemGroup>
-    <!--<PackageReference Include="Microsoft.Private.CoreFx.NETCoreApp" Version="4.6.0-preview3-26501-01" />-->
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.3" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.3.921" />
     <PackageReference Include="System.Data.SqlClient" Version="4.7.0-dev.18621.1" />
   </ItemGroup>
 
@@ -20,8 +17,4 @@
     </Reference>
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'"><!--<PackageConflictPreferredPackages>Microsoft.Private.CoreFx.NETCoreApp.4.6.0-preview3-26501-01;runtime.win-x64.Microsoft.Private.CoreFx.NETCoreApp;$(PackageConflictPreferredPackages)</PackageConflictPreferredPackages>-->
-  
-    <PlatformTarget>x64</PlatformTarget>
-  </PropertyGroup>
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+ <packageSources>
+    <add key="bdn-ci" value="https://ci.appveyor.com/nuget/benchmarkdotnet" />
+ </packageSources>
+</configuration>


### PR DESCRIPTION
This is a fix for https://github.com/dotnet/BenchmarkDotNet/issues/954

To tell the long story short, all you need to do right now to run against local CoreFX build is providing the path to CoreRun.exe via `--coreRun` console line argument.

It's important to provide the path to the right CoreRun.exe, because CoreFX\artifacts\bin has at least few of them.

The right one is: `artifacts\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe` 

Which one is the right one? The one where CoreFX build puts updated dlls after every CoreFX rebuild. For example: you change System.Collections.Immutable.dll and rebuild CoreFX, then the scripts are going to update System.Collections.Immutable.dll in `artifacts\bin\runtime\netcoreapp-Windows_NT-Release-x64\`

How it works? When we use CoreRun.exe to run a .NET dll it does not care what it references, it loads the .dlls from it's folder first. So when you reference System.ABC.dll v 4.5 but CoreRun has System.ABC v 4.5.1 then it's going to load and use 4.5.1.

How to run the benchmarks:

```cmd
dotnet run -c Release --filter * --coreRun "C:\Projects\corefx_fresh\artifacts\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
```

Sample output from my machine:

```log
PS C:\Projects\SqlBench> dotnet run -c Release --filter * --coreRun "C:\Projects\corefx_fresh\artifacts\bin\runtime\netcoreapp-Windows_NT-Release-x64\CoreRun.exe"
C:\Projects\SqlBench\SqlBench.csproj : warning NU1603: SqlBench depends on System.Data.SqlClient (>= 4.7.0-dev.18621.1) but System.Data.SqlClient 4.7.0-dev.18621.1 was not found. An approximate best match of System.Data.SqlClient 4.7.0-preview.18551.3 was resolved.
C:\Projects\SqlBench\SqlBench.csproj : warning NU1603: SqlBench depends on System.Data.SqlClient (>= 4.7.0-dev.18621.1) but System.Data.SqlClient 4.7.0-dev.18621.1 was not found. An approximate best match of System.Data.SqlClient 4.7.0-preview.18551.3 was resolved.
// Validating benchmarks:
// ***** BenchmarkRunner: Start   *****
// ***** Building 1 exe(s) in Parallel: Start   *****
// start dotnet restore  /p:UseSharedCompilation=false in C:\Projects\SqlBench\bin\Release\netcoreapp3.0\7a8bcd11-9cfe-4510-bb7d-8f076dfc868b
// command took 2,02s and exited with 0
// start dotnet build -c Release  --no-restore /p:UseSharedCompilation=false in C:\Projects\SqlBench\bin\Release\netcoreapp3.0\7a8bcd11-9cfe-4510-bb7d-8f076dfc868b
// command took 3,51s and exited with 0
// start dotnet publish -c Release  --no-build --no-restore /p:UseSharedCompilation=false in C:\Projects\SqlBench\bin\Release\netcoreapp3.0\7a8bcd11-9cfe-4510-bb7d-8f076dfc868b
// command took 1,46s and exited with 0
// ***** Done, took 00:00:07 (7.97 sec)   *****
// Found benchmarks:
//   WriteBenchmarks.SyncGuid: Job-FIHGCA(Runtime=Core, Toolchain=CoreRun, InvocationCount=1, UnrollFactor=1)

// **************************
// Benchmark: WriteBenchmarks.SyncGuid: Job-FIHGCA(Runtime=Core, Toolchain=CoreRun, InvocationCount=1, UnrollFactor=1)
// *** Execute ***
// Launch: 1 / 1
// Execute: C:\Projects\corefx_fresh\artifacts\bin\runtime\4393309a-0981-487b-a1d1-0714f6642318\CoreRun.exe "7a8bcd11-9cfe-4510-bb7d-8f076dfc868b.dll" --benchmarkName "BenchmarkSqlWrite.WriteBenchmarks.SyncGuid" --job "Runtime=Core, Toolchain=CoreRun, InvocationCount=1, UnrollFactor=1" --benchmarkId 0 in C:\Projects\SqlBench\bin\Release\netcoreapp3.0\7a8bcd11-9cfe-4510-bb7d-8f076dfc868b\bin\Release\netcoreapp3.0\publish
// BeforeAnythingElse

// Benchmark Process Environment Information:
// Runtime=.NET Core ? (CoreCLR 4.6.27302.02, CoreFX 4.7.19.5301), 64bit RyuJIT
// GC=Concurrent Workstation
// Job: Job-RJYJTV(Runtime=Core, InvocationCount=1, UnrollFactor=1)
```